### PR TITLE
CLDR-19315 production data for release-48-2-beta2 (from ICU integration)

### DIFF
--- a/production/common/main/ko.xml
+++ b/production/common/main/ko.xml
@@ -2092,12 +2092,18 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 					<dayPeriodContext type="format">
 						<dayPeriodWidth type="abbreviated">
 							<dayPeriod type="midnight">자정</dayPeriod>
+							<dayPeriod type="am">오전</dayPeriod>
 							<dayPeriod type="noon">정오</dayPeriod>
+							<dayPeriod type="pm">오후</dayPeriod>
 							<dayPeriod type="morning1">아침</dayPeriod>
 							<dayPeriod type="morning2">오전</dayPeriod>
 							<dayPeriod type="afternoon1">오후</dayPeriod>
 							<dayPeriod type="evening1">저녁</dayPeriod>
 							<dayPeriod type="night1">밤</dayPeriod>
+						</dayPeriodWidth>
+						<dayPeriodWidth type="narrow">
+							<dayPeriod type="am">오전</dayPeriod>
+							<dayPeriod type="pm">오후</dayPeriod>
 						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">오전</dayPeriod>
@@ -2105,6 +2111,14 @@ Warnings: All cp values have U+FE0F characters removed. See /annotationsDerived/
 						</dayPeriodWidth>
 					</dayPeriodContext>
 					<dayPeriodContext type="stand-alone">
+						<dayPeriodWidth type="abbreviated">
+							<dayPeriod type="am">오전</dayPeriod>
+							<dayPeriod type="pm">오후</dayPeriod>
+						</dayPeriodWidth>
+						<dayPeriodWidth type="narrow">
+							<dayPeriod type="am">오전</dayPeriod>
+							<dayPeriod type="pm">오후</dayPeriod>
+						</dayPeriodWidth>
 						<dayPeriodWidth type="wide">
 							<dayPeriod type="am">오전</dayPeriod>
 							<dayPeriod type="pm">오후</dayPeriod>

--- a/production/common/main/ps.xml
+++ b/production/common/main/ps.xml
@@ -1207,6 +1207,10 @@ CLDR data files are interpreted according to the LDML specification (http://unic
 				</quarters>
 				<dayPeriods>
 					<dayPeriodContext type="format">
+						<dayPeriodWidth type="abbreviated">
+							<dayPeriod type="am">غ.م.</dayPeriod>
+							<dayPeriod type="pm">غ.و.</dayPeriod>
+						</dayPeriodWidth>
 						<dayPeriodWidth type="narrow">
 							<dayPeriod type="am">غ.م.</dayPeriod>
 							<dayPeriod type="pm">غ.و.</dayPeriod>

--- a/production/common/supplemental/metaZones.xml
+++ b/production/common/supplemental/metaZones.xml
@@ -735,7 +735,7 @@ For terms of use, see http://www.unicode.org/copyright.html
 				<usesMetazone mzone="Atlantic"/>
 			</timezone>
 			<timezone type="America/Vancouver">
-				<usesMetazone mzone="America_Pacific"/>
+				<usesMetazone mzone="America_Pacific" stdOffset="-08" dstOffset="-07"/>
 			</timezone>
 			<timezone type="America/Whitehorse">
 				<usesMetazone to="2020-11-01 07:00" mzone="America_Pacific"/>


### PR DESCRIPTION
Production data update for CLDR 48.2 beta2, generated during CLDR-ICU integration. Just the ko/ps AM/PM updates, and the added timezone data for Vancouver.

##### Checklist

- [x] Issue filed: https://unicode-org.atlassian.net/browse/CLDR-19315
- [x] Updated PR title and link in previous line to include Issue number

